### PR TITLE
Resolve "dbexporter.py healthcheck not working"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       MQTT_PASSWORD: ${MQTT_PASSWORD}
     healthcheck:
       test:
-        ["CMD", "ps", "aux", "|", "grep", "[d]bexporter.py", "||", "exit", "1"]
+        ["CMD-SHELL", "ps aux | grep dbexporter.py | grep -v grep || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
The healthcheck for the dbexporter container was not working properly. This test command was now fixed.

Closes #6 