### PR TITLE
Add Linter and check for expected environment variables in dbexporter.py

### DIFF
--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.github.com:443
             files.pythonhosted.org:443

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,3 +94,14 @@ repos:
           - --max-average=A
           - --max-modules=A
           - --max-absolute=A
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint-docker
+        files: \.(dockerfile|Dockerfile)$|^Dockerfile
+  - repo: https://github.com/docker-compose-linter/pre-commit-dclint
+    rev: v3.1.0
+    hooks:
+      - id: dclint-docker
+        files: (docker-)?compose\.ya?ml$
+        # args: [--fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY dbexporter.py /app/dbexporter.py
 
+# hadolint ignore=DL3008,DL3013
 RUN --mount=type=cache,target=/var/lib/apt/,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=tmpfs,target=/var/log/apt/ \
@@ -20,6 +21,6 @@ RUN --mount=type=cache,target=/var/lib/apt/,sharing=locked \
         procps \
     && locale-gen en_US.UTF.8 \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --compile paho-mqtt influxdb-client
+    && python -m pip install --no-cache-dir --compile paho-mqtt influxdb-client
 
 ENTRYPOINT ["python", "/app/dbexporter.py"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ in the visualization.
    a static IP address to the plug(s).
 2. Install the latest version of Tasmota on your devices.
 3. Create a password file for mosquitto by running the official docker image to
-   leverage the `mosquitto_passwd` command.
+   execute the `mosquitto_passwd` command.
 
    ```bash
    docker run -it eclipse-mosquitto:latest sh
@@ -54,11 +54,12 @@ in the visualization.
    mqtt_user:................
    ```
 
-   Copy the content of `passwd_file` into `mosquitto/passwd_file` on your host
+   Copy the content of `passwd_file` into `./mosquitto/passwd_file` on your host
    system.
 
-   (Do **not** change the path to `passwd_file` file within
-   `mosquitto/mosquitto.conf`!)
+   Do **not** change the path to `passwd_file` file within
+   `./mosquitto/mosquitto.conf`. This file must be present in the working
+   directory in which docker is run later on.
 
 4. Run the docker-compose file to start the services, but first, ensure that the
    required environment variables are set.

--- a/dbexporter.py
+++ b/dbexporter.py
@@ -28,9 +28,22 @@ INFLUXDB_TOKEN = os.getenv("INFLUXDB_TOKEN")
 INFLUXDB_BUCKET = os.getenv("INFLUXDB_DATABASE")
 INFLUXDB_ORG = os.getenv("INFLUXDB_ORG")
 
+if not all((INFLUXDB_URL, INFLUXDB_TOKEN, INFLUXDB_ORG, INFLUXDB_ORG)):
+    raise ValueError(
+        "The environment variables INFLUXDB_URL, INFLUXDB_TOKEN, INFLUXDB_ORG,"
+        " and INFLUXDB_ORG must be set.",
+    )
+
 MQTT_ADDRESS = os.getenv("MQTT_HOST")
 MQTT_USERNAME = os.getenv("MQTT_USERNAME")
 MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
+
+if not all((MQTT_ADDRESS, MQTT_USERNAME, MQTT_PASSWORD)):
+    raise ValueError(
+        "The environment variables MQTT_ADDRESS, MQTT_USERNAME, and"
+        " MQTT_PASSWORD must be set.",
+    )
+
 MQTT_TOPIC = "tele/+/SENSOR"
 MQTT_REGEX = "tele/([^/]+)/([^/]+)"
 MQTT_CLIENT_ID = "MQTT_InfluxDB_Bridge"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,15 +3,17 @@
 # GitHub: https://github.com/btschwertfeger
 #
 
+name: tasmota-plug-monitoring
+
 services:
   dbexporter:
     build:
       context: .
       dockerfile: Dockerfile
     depends_on:
-      mosquitto-server:
-        condition: service_healthy
       influxdb:
+        condition: service_healthy
+      mosquitto-server:
         condition: service_healthy
     environment:
       TZ: Europe/Berlin
@@ -26,6 +28,9 @@ services:
       MQTT_HOST: ${MQTT_HOST}
       MQTT_USERNAME: ${MQTT_USERNAME}
       MQTT_PASSWORD: ${MQTT_PASSWORD}
+    networks:
+      - tasmota_plug_monitoring_network
+    restart: always
     healthcheck:
       test:
         ["CMD-SHELL", "ps aux | grep dbexporter.py | grep -v grep || exit 1"]
@@ -33,26 +38,66 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    restart: always
-    networks:
-      - tasmota_plug_monitoring_network
 
-  mosquitto-server:
-    image: eclipse-mosquitto:2.0.20
+  grafana:
+    image: grafana/grafana:11.4.0
+    volumes:
+      - grafana_data:/var/lib/grafana
     environment:
       TZ: Europe/Berlin
     ports:
-      - 1883:1883
-      - 9001:9001
+      - "0.0.0.0:3000:3000"
+    networks:
+      - tasmota_plug_monitoring_network
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  influxdb:
+    image: influxdb:2.7.11
+    volumes:
+      - influxdb_data:/var/lib/influxdb2
+    environment:
+      TZ: Europe/Berlin
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUXDB_USERNAME}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_PASSWORD}
+      DOCKER_INFLUXDB_INIT_ORG: ${INFLUXDB_ORG}
+      DOCKER_INFLUXDB_INIT_BUCKET: ${INFLUXDB_DATABASE}
+      DOCKER_INFLUXDB_INIT_RETENTION: 365d
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUXDB_TOKEN}
+      # DOCKER_INFLUXDB_HTTP_LOG_ENABLED: true
+      DOCKER_INFLUXDB_LOGGING_LEVEL: warning
+    ports:
+      - "0.0.0.0:8086:8086"
+    networks:
+      - tasmota_plug_monitoring_network
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "influx ping -host http://localhost:8086 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 3
+
+  mosquitto-server:
+    image: eclipse-mosquitto:2.0.20
     volumes:
       - mosquitto_data:/mosquitto/data
       - mosquitto_log:/mosquitto/log
-      - ${PWD}/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
-    restart: always
-    networks:
-      - tasmota_plug_monitoring_network
+      - ${PWD}/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     secrets:
       - mqtt_passwd_file
+    environment:
+      TZ: Europe/Berlin
+    ports:
+      - "0.0.0.0:1883:1883"
+      - "0.0.0.0:9001:9001"
+    networks:
+      - tasmota_plug_monitoring_network
+    restart: always
     healthcheck:
       test:
         [
@@ -73,48 +118,9 @@ services:
       timeout: 10s
       retries: 3
 
-  influxdb:
-    image: influxdb:2.7.11
-    ports:
-      - 8086:8086
-    volumes:
-      - influxdb_data:/var/lib/influxdb2
-    environment:
-      TZ: Europe/Berlin
-      DOCKER_INFLUXDB_INIT_MODE: setup
-      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUXDB_USERNAME}
-      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_PASSWORD}
-      DOCKER_INFLUXDB_INIT_ORG: ${INFLUXDB_ORG}
-      DOCKER_INFLUXDB_INIT_BUCKET: ${INFLUXDB_DATABASE}
-      DOCKER_INFLUXDB_INIT_RETENTION: 365d
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUXDB_TOKEN}
-      # DOCKER_INFLUXDB_HTTP_LOG_ENABLED: true
-      DOCKER_INFLUXDB_LOGGING_LEVEL: warning
-    restart: always
-    networks:
-      - tasmota_plug_monitoring_network
-    healthcheck:
-      test: ["CMD-SHELL", "influx ping -host http://localhost:8086 || exit 1"]
-      interval: 15s
-      timeout: 10s
-      retries: 3
-
-  grafana:
-    image: grafana/grafana:11.4.0
-    ports:
-      - 3000:3000
-    volumes:
-      - grafana_data:/var/lib/grafana
-    restart: always
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    environment:
-      TZ: Europe/Berlin
-    networks:
-      - tasmota_plug_monitoring_network
+networks:
+  tasmota_plug_monitoring_network:
+    driver: bridge
 
 volumes:
   mosquitto_data:
@@ -125,10 +131,6 @@ volumes:
     external: false
   grafana_data:
     external: false
-
-networks:
-  tasmota_plug_monitoring_network:
-    driver: bridge
 
 secrets:
   mqtt_passwd_file:


### PR DESCRIPTION
- Add linter for Dockerfile and compose file
- Raise error in dbexporter in case expected environment variables are missing
- Containers now always restart
- Mount config as read only